### PR TITLE
Refactor before_template method for item rendering simplification

### DIFF
--- a/lib/plutonium/ui/panel.rb
+++ b/lib/plutonium/ui/panel.rb
@@ -17,12 +17,8 @@ module Plutonium
         @content = content
       end
 
-      def before_template
-        vanish do
-          @items.each do |item|
-            render item
-          end
-        end
+      def before_template(&)
+        vanish(&)
         super
       end
 


### PR DESCRIPTION
Simplify the `before_template` method to enhance item rendering by using a block.